### PR TITLE
Update welcome messages with corrected GitHub download links

### DIFF
--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -9,7 +9,7 @@ module.exports = {
 		+ 'On this server, you\'ll find everything you need to download and learn how to use Pokémon Studio & Pokémon SDK to create your own Pokémon fangame. '
 		+ 'You can also discuss the software and your projects, and meet a whole community made out of Pokémon and creation fans!\n\n'
 		+ 'Now you can:\n'
-		+ `${config.customEmoji.dot} [Download Pokémon Studio (including Pokémon SDK)](<https://github.com/PokemonWorkshop/PokemonStudio/releases/latest>) on GitHub \n`
+		+ `${config.customEmoji.dot} [Download Pokémon Studio](<https://github.com/PokemonWorkshop/PokemonStudio/releases/latest>) (including Pokémon SDK) on GitHub \n`
 		+ `${config.customEmoji.dot} Customize your server experience in the "Channels & Roles" section \n`
 		+ `${config.customEmoji.dot} Take the time to re-read the ${channelMention(config.channel.rules)}!`;
 
@@ -17,7 +17,7 @@ module.exports = {
 		+ 'Sur ce serveur, tu trouveras de quoi télécharger et apprendre à utiliser Pokémon Studio & Pokémon SDK pour créer ton propre fangame Pokémon. '
 		+ 'Tu pourras aussi discuter du logiciel et de tes projets, ainsi que rencontrer toute une communauté de fans de Pokémon et de création !\n\n'
 		+ 'Tu peux maintenant :\n'
-		+ `${config.customEmoji.dot} [Télécharger Pokémon Studio (incluant Pokémon SDK)](<https://github.com/PokemonWorkshop/PokemonStudio/releases/latest>) sur GitHub \n`
+		+ `${config.customEmoji.dot} [Télécharger Pokémon Studio](<https://github.com/PokemonWorkshop/PokemonStudio/releases/latest>) (incluant Pokémon SDK) sur GitHub \n`
 		+ `${config.customEmoji.dot} Personnaliser ton expérience sur le serveur dans la section \"Salons et rôles\" \n`
 		+ `${config.customEmoji.dot} Prendre le temps de relire les ${channelMention(config.channel.rules)} !`;
 

--- a/src/events/guildMemberAdd.js
+++ b/src/events/guildMemberAdd.js
@@ -9,7 +9,7 @@ module.exports = {
 		+ 'On this server, you\'ll find everything you need to download and learn how to use Pokémon Studio & Pokémon SDK to create your own Pokémon fangame. '
 		+ 'You can also discuss the software and your projects, and meet a whole community made out of Pokémon and creation fans!\n\n'
 		+ 'Now you can:\n'
-		+ `${config.customEmoji.dot} Download Pokémon Studio (including Pokémon SDK) in ${channelMention(config.channel.psdkLinks)}\n`
+		+ `${config.customEmoji.dot} [Download Pokémon Studio (including Pokémon SDK)](<https://github.com/PokemonWorkshop/PokemonStudio/releases/latest>) on GitHub \n`
 		+ `${config.customEmoji.dot} Customize your server experience in the "Channels & Roles" section \n`
 		+ `${config.customEmoji.dot} Take the time to re-read the ${channelMention(config.channel.rules)}!`;
 
@@ -17,7 +17,7 @@ module.exports = {
 		+ 'Sur ce serveur, tu trouveras de quoi télécharger et apprendre à utiliser Pokémon Studio & Pokémon SDK pour créer ton propre fangame Pokémon. '
 		+ 'Tu pourras aussi discuter du logiciel et de tes projets, ainsi que rencontrer toute une communauté de fans de Pokémon et de création !\n\n'
 		+ 'Tu peux maintenant :\n'
-		+ `${config.customEmoji.dot} Télécharger Pokémon Studio (incluant Pokémon SDK) dans ${channelMention(config.channel.psdkLinks)}\n`
+		+ `${config.customEmoji.dot} [Télécharger Pokémon Studio (incluant Pokémon SDK)](<https://github.com/PokemonWorkshop/PokemonStudio/releases/latest>) sur GitHub \n`
 		+ `${config.customEmoji.dot} Personnaliser ton expérience sur le serveur dans la section \"Salons et rôles\" \n`
 		+ `${config.customEmoji.dot} Prendre le temps de relire les ${channelMention(config.channel.rules)} !`;
 


### PR DESCRIPTION
## Description

This MR:
- Remove the old link to links Discord channel that was deleted
- Replace them with a GitHub direct link to the latest version to download Pokémon Studio

## Tests

- [x] Check that the message sent is properly displayed with a link and no regression